### PR TITLE
GCI-177-Remove-those-useless-parentheses-from-GZIPResponseStream

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/GZIPResponseStream.java
+++ b/web/src/main/java/org/openmrs/web/filter/GZIPResponseStream.java
@@ -152,7 +152,7 @@ public class GZIPResponseStream extends ServletOutputStream {
 	}
 	
 	public boolean closed() {
-		return (this.closed);
+		return this.closed;
 	}
 	
 	public void reset() {


### PR DESCRIPTION
Changed #L155
From : return (this.closed);
To: return this.closed;

GCI-177-Remove-those-useless-parentheses-from-GZIPResponseStream

## Description
Changed #L155
From : return (this.closed);
To: return this.closed;

##Issue I worked on
https://issues.openmrs.org/browse/GCI-177
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [ ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

